### PR TITLE
Shared as a variable

### DIFF
--- a/Haptico/Classes/Haptico.swift
+++ b/Haptico/Classes/Haptico.swift
@@ -57,9 +57,7 @@ public final class Haptico {
     
     public var logEnabled: Bool = true
     
-    public class func shared() -> Haptico {
-        return sharedHaptico
-    }
+    public static var shared: Haptico = sharedHaptico
     
     public func prepare() throws {
         guard let engine = engine else {


### PR DESCRIPTION
`shared` is now a variable for more consistency with recent Cocoa frameworks updates that replace `shared()` to `shared`