### PR TITLE
Add capability for new devices

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ All notable changes to this project will be documented in this file.
 ## 1.0.2
 
 - adding new iPhones
+
+## 1.2.0
+
+- adding capability to use CoreHaptics to detect if capable of haptics for iOS 13+ instead of having to rely on a list of devices

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,5 @@
 use_frameworks!
-platform :ios, '13.0'
+platform :ios, '9.0'
 
 target 'Haptico_Example' do
   pod 'Haptico', :path => '../'

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,5 @@
 use_frameworks!
-platform :ios, '9.0'
+platform :ios, '13.0'
 
 target 'Haptico_Example' do
   pod 'Haptico', :path => '../'

--- a/Haptico.podspec
+++ b/Haptico.podspec
@@ -28,7 +28,7 @@ Haptico - easy to use haptic feedback generator with pattern-play support. Check
   s.source           = { :git => 'https://github.com/isapozhnik/Haptico.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '9.0'
 
   s.source_files = 'Sources/Haptico/**/*'
   

--- a/Haptico.podspec
+++ b/Haptico.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Haptico'
-  s.version          = '1.1.1'
+  s.version          = '1.2.0'
   s.summary          = 'Haptico - easy to use haptic feedback generator with pattern-play support'
 
 # This description is used to generate tags and improve search results.
@@ -28,7 +28,7 @@ Haptico - easy to use haptic feedback generator with pattern-play support. Check
   s.source           = { :git => 'https://github.com/isapozhnik/Haptico.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '13.0'
 
   s.source_files = 'Sources/Haptico/**/*'
   

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Haptico",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v9),
     ],
     products: [
         .library(name: "Haptico", targets: ["Haptico"])

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Haptico",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v13),
     ],
     products: [
         .library(name: "Haptico", targets: ["Haptico"])

--- a/Sources/Haptico/Extensions/UIDevice+Extensions.swift
+++ b/Sources/Haptico/Extensions/UIDevice+Extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreHaptics
 
 // https://github.com/schickling/Device.swift/blob/master/Device/UIDeviceExtension.swift
 // https://ipsw.me/otas
@@ -13,11 +14,11 @@ import UIKit
 internal extension UIDevice {
     
     /// Returns the `DeviceType` of the device in use
-    internal var deviceType: DeviceType {
+    var deviceType: DeviceType {
         return DeviceType.current
     }
     
-    internal var hasTapticEngine: Bool {
+    var hasTapticEngine: Bool {
         get {
             return deviceType == .iPhone6S || deviceType == .iPhone6SPlus ||
                 deviceType == .iPhone7 || deviceType == .iPhone7Plus ||
@@ -31,16 +32,20 @@ internal extension UIDevice {
         }
     }
     
-    internal var hasHapticFeedback: Bool {
+    var hasHapticFeedback: Bool {
         get {
-            return deviceType == .iPhone7 || deviceType == .iPhone7Plus ||
-                deviceType == .iPhone8 || deviceType == .iPhone8Plus ||
-                deviceType == .iPhoneX || deviceType == .iPhoneXR ||
-                deviceType == .iPhoneXS || deviceType == .iPhoneXSMax ||
-                deviceType == .iPhone11 || deviceType == .iPhone11Pro ||
-                deviceType == .iPhone11ProMax || deviceType == .iPhoneSEGen2 ||
-                deviceType == .iPhone12Mini ||  deviceType == .iPhone12 ||
-                deviceType == .iPhone12Pro  ||  deviceType == .iPhone12ProMax
+            if #available(iOS 13.0, *) {
+                return CHHapticEngine.capabilitiesForHardware().supportsHaptics
+            } else {
+                return deviceType == .iPhone7 || deviceType == .iPhone7Plus ||
+                    deviceType == .iPhone8 || deviceType == .iPhone8Plus ||
+                    deviceType == .iPhoneX || deviceType == .iPhoneXR ||
+                    deviceType == .iPhoneXS || deviceType == .iPhoneXSMax ||
+                    deviceType == .iPhone11 || deviceType == .iPhone11Pro ||
+                    deviceType == .iPhone11ProMax || deviceType == .iPhoneSEGen2 ||
+                    deviceType == .iPhone12Mini ||  deviceType == .iPhone12 ||
+                    deviceType == .iPhone12Pro  ||  deviceType == .iPhone12ProMax
+            }
         }
     }
 }


### PR DESCRIPTION
Set hasHapticFeedback to use CoreHaptics to detect if device has haptic engine if device is using iOS 13+ instead of having to rely on a device list that has to be updated each time new iPhones are released.