### PR TITLE
Add `rigid` and `soft` HapticoImpacts + UISelectionFeedbackGenerator

### DIFF
--- a/Sources/Haptico/Engines/PatternEngine.swift
+++ b/Sources/Haptico/Engines/PatternEngine.swift
@@ -13,6 +13,12 @@ class PatternEngine {
         case signalHeavy = "O"
         case signalMedium = "o"
         case signalLight = "."
+        
+        @available(iOS 13.0, *)
+        case signalRigid = "r"
+        
+        @available(iOS 13.0, *)
+        case signalSoft = "s"
     }
     
     var isFinished: Bool {
@@ -35,7 +41,7 @@ class PatternEngine {
     }
     
     func generate() {
-        for (_, character) in pattern.pattern.enumerated() {
+        for character in pattern.pattern {
             if character == PatternChar.space.rawValue {
                 queue.addOperation(PauseOperation(delay: pattern.delay))
             } else if character == PatternChar.signalHeavy.rawValue {
@@ -44,6 +50,10 @@ class PatternEngine {
                 queue.addOperation(SignalOperation(hapticEngine: engine, impact: .medium, pauseDuration: pauseDuration))
             } else if character == PatternChar.signalLight.rawValue {
                 queue.addOperation(SignalOperation(hapticEngine: engine, impact: .light, pauseDuration: pauseDuration))
+            } else if #available(iOS 13.0, *), character == PatternChar.signalRigid.rawValue {
+                queue.addOperation(SignalOperation(hapticEngine: engine, impact: .rigid, pauseDuration: pauseDuration))
+            } else if #available(iOS 13.0, *), character == PatternChar.signalSoft.rawValue {
+                queue.addOperation(SignalOperation(hapticEngine: engine, impact: .soft, pauseDuration: pauseDuration))
             }
         }
     }

--- a/Sources/Haptico/Extensions/HapticoImpact+FeedbackStyle.swift
+++ b/Sources/Haptico/Extensions/HapticoImpact+FeedbackStyle.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+internal extension HapticoImpact {
+    
+    var feedbackStyle: UIImpactFeedbackGenerator.FeedbackStyle {
+        switch self {
+        case .light:
+            return .light
+        case .medium:
+            return .medium
+        case .heavy:
+            return .heavy
+        case .rigid:
+            if #available(iOS 13.0, *) {
+                return .rigid
+            } else {
+                return .medium
+            }
+        case .soft:
+            if #available(iOS 13.0, *) {
+                return .soft
+            } else {
+                return .light
+            }
+        }
+    }
+    
+}

--- a/Sources/Haptico/Haptico.swift
+++ b/Sources/Haptico/Haptico.swift
@@ -19,10 +19,26 @@ public enum HapticoNotification {
     case error
 }
 
-public enum HapticoImpact {
+public enum HapticoImpact: CaseIterable {
     case light
     case medium
     case heavy
+    
+    @available(iOS 13.0, *)
+    case rigid
+    
+    @available(iOS 13.0, *)
+    case soft
+    
+    public static var allCases: [HapticoImpact] {
+        var cases: [HapticoImpact] = [.light, .medium, .heavy]
+        
+        if #available(iOS 13.0, *) {
+            cases.append(contentsOf: [.soft, .rigid])
+        }
+        
+        return cases
+    }
 }
 
 public protocol HapticoEngine {


### PR DESCRIPTION
- Add `rigid` and `soft` enum cases to `HapticoImpact`. Mark as available from iOS13
- Add the ability to use the new rigid and soft impacts in the `PatternEngine`. "r" - rigid, "s" - soft
- Add `selectionGenerator: UISelectionFeedbackGenerator` to `HapticFeedbackNotificationEngine`. It can be fired by calling `Haptico.shared().selectionChanged()` 
- Store `UIImpactFeedbackGenerator`s in an array instead of a tuple for simplicity

Thanks for an awesome lib!